### PR TITLE
ci: Add an e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,8 @@ jobs:
         run: cargo test --no-run
       - name: Run tests
         run: cargo test -- --nocapture --quiet
+      - name: Install
+        run: cargo install --path . --debug
+      - name: Self test integration
+        run: ./ci/selftest.sh
+

--- a/ci/selftest.sh
+++ b/ci/selftest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Clone our own git repository and vendor our own sources
+# using --linux-only, and verify that `winapi` is just a stub.
+set -xeuo pipefail
+srcdir=$(git rev-parse --show-toplevel)
+tmpd=$(mktemp -d)
+tmp_git=${tmpd}/self
+git clone ${srcdir} ${tmp_git}
+cd ${tmp_git}
+cargo-vendor-filterer --linux-only
+test $(stat --printf="%s" vendor/winapi/src/lib.rs) = 0
+test $(ls vendor/winapi/src | wc -l) = 1
+echo "ok"
+rm "${tmpd}" -rf


### PR DESCRIPTION
Clone our own git repository and vendor our own sources
using --linux-only, and verify that `winapi` is just a stub.