### PR TITLE
Add `--format=tar` and `--format=tar.zstd`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "openssl",
  "serde",
  "serde_json",
+ "tempfile",
  "toml",
 ]
 
@@ -125,6 +126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -198,6 +208,15 @@ checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -324,6 +343,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +437,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ toml = "0.5"
 openssl = "0.10.40"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.80"
+tempfile = "3.3.0"
 
 [dependencies.clap]
 features = ["derive"]

--- a/README.md
+++ b/README.md
@@ -44,29 +44,21 @@ All of these options have corresponding CLI flags; see `cargo vendor-filterer --
 
 # Generating reproducible vendor tarballs
 
-The output from this project is a directory; however, many projects will
-want to serialize this to a single file archive (such as tar) in order
-to attach to e.g. a Github/Gitlab release.
+You can also provide `--format=tar.zstd` to output a reproducible tar archive
+compressed via zstd; the default filename will be `vendor.tar.zstd`.  Similarly
+there is `--format=tar` to output an uncompressed tar archive, which you
+can compress however you like.
 
-For more information on how to do this, see https://reproducible-builds.org/docs/archives/
+This option requires:
 
-An example script:
+ - An external GNU `tar` program
+ - An external `zstd` program (for `--format=tar.zstd`)
+ - `SOURCE_DATE_EPOCH` set in the environment, or an external `git` and the working directory must be a git repository
 
-```
-#!/usr/bin/bash
-set -xeuo pipefail
-# Vendor dependencies; this assumes you are using metadata in Cargo.toml
-cargo vendor-filterer
-# Gather the timestamp from git; https://reproducible-builds.org/docs/source-date-epoch/
-SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
-# Example from https://reproducible-builds.org/docs/archives/ modified to also use zstd compression
-tar --sort=name \
-      --mtime="@${SOURCE_DATE_EPOCH}" \
-      --owner=0 --group=0 --numeric-owner \
-      --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-      --zstd \
-      -cf vendor.tar.zstd vendor
-rm vendor -rf
+This uses the suggested code from https://reproducible-builds.org/docs/archives/
+to output a reproducible archive; in other words, another process/tool
+can also perform a `git clone` of your project and regenerate the vendor
+tarball to verify it.
 ```
 
 # TODO

--- a/ci/selftest.sh
+++ b/ci/selftest.sh
@@ -33,8 +33,24 @@ echo "ok linux only"
 echo "Verifying linux as subcommand"
 cargo vendor-filterer --platform=x86_64-unknown-linux-gnu
 verify_no_windows
+test '!' -f vendor.tar.zstd
 rm vendor -rf
 echo "ok linux only subcommand"
+
+echo "Verifying linux + output to tar zstd"
+cargo vendor-filterer --platform=x86_64-unknown-linux-gnu --format=tar.zstd
+zstdcat vendor.tar.zstd | tar tf - > out.txt
+grep -qF './anyhow' out.txt
+rm -v vendor.tar.zstd out.txt
+echo "ok linux + output to tar"
+
+echo "Verifying linux + output to tar"
+cargo vendor-filterer --platform=x86_64-unknown-linux-gnu --format=tar
+tar tf - < vendor.tar > out.txt
+grep -qF './anyhow' out.txt
+rm -v vendor.tar out.txt
+echo "ok linux + output to tar"
+
 
 # Default
 cargo-vendor-filterer


### PR DESCRIPTION
For many of our projects we want to attach them to e.g.
Github releases, which is best done as a single file archive.
We spend a bit of effort to make the output of this reproducible.