### PR TITLE
Add support for globs `*` in `platforms`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,10 +58,12 @@ dependencies = [
  "cargo-lock",
  "cargo_metadata",
  "clap",
+ "either",
  "hex",
  "openssl",
  "serde",
  "serde_json",
+ "smallvec",
  "tempfile",
  "toml",
 ]
@@ -127,6 +129,12 @@ checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "either"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "fastrand"
@@ -421,6 +429,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ openssl = "0.10.40"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.80"
 tempfile = "3.3.0"
+smallvec = "1.9.0"
+either = "1.7.0"
 
 [dependencies.clap]
 features = ["derive"]

--- a/ci/selftest.sh
+++ b/ci/selftest.sh
@@ -26,6 +26,13 @@ test '!' -d "${hex_benches}"
 rm target/vendor -rf
 echo "ok linux only"
 
+echo "Verifying linux"
+cargo-vendor-filterer '--platform=*-unknown-linux-gnu' target/vendor
+verify_no_windows target/vendor
+test '!' -d "${hex_benches}"
+rm target/vendor -rf
+echo "ok linux only via glob"
+
 echo "Verifying linux as subcommand"
 cargo vendor-filterer --platform=x86_64-unknown-linux-gnu
 verify_no_windows vendor


### PR DESCRIPTION
This way one can more conveniently do e.g.
`platforms: ["*-linux-gnu"]`

Closes: https://github.com/cgwalters/cargo-vendor-filterer/issues/23